### PR TITLE
HCP Migration of Workspaces in PulsePixel/PixelPredict repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+**/.terraform/*
+.terraform.lock.*
+*.tfstate
+*.tfstate.*
+_hcp-migrate-configs/
+!_hcp-migrate-configs/terraform.tfstate*

--- a/_hcp-migrate-configs/terraform.tfstate
+++ b/_hcp-migrate-configs/terraform.tfstate
@@ -1,0 +1,212 @@
+{
+  "version": 4,
+  "terraform_version": "1.9.2",
+  "serial": 6,
+  "lineage": "15bac955-a1e2-94f6-ff97-341c4e5af625",
+  "outputs": {
+    "count_dir_skipped": {
+      "value": 0,
+      "type": "number"
+    },
+    "list_of_new_project_ids": {
+      "value": [
+        "prj-xoJ9naqKrG19yiAQ"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string"
+        ]
+      ]
+    },
+    "list_of_new_project_names": {
+      "value": [
+        "pixel_predict"
+      ],
+      "type": [
+        "tuple",
+        [
+          "string"
+        ]
+      ]
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "tfe_project",
+      "name": "list_of_new_projects",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "pixel_predict",
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/PixelPredict",
+            "id": "prj-xoJ9naqKrG19yiAQ",
+            "name": "pixel_predict",
+            "organization": "PulsePixel"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"PixelPredict\"]",
+      "mode": "data",
+      "type": "tfe_project",
+      "name": "project",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "description": "Created by Terrafrom Migrate from the Github Repository: PulsePixel/PixelPredict",
+            "id": "prj-xoJ9naqKrG19yiAQ",
+            "name": "pixel_predict",
+            "organization": "PulsePixel",
+            "workspace_ids": []
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"PixelPredict\"]",
+      "mode": "managed",
+      "type": "tfe_workspace",
+      "name": "workspaces",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfe\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 1,
+          "attributes": {
+            "agent_pool_id": "",
+            "allow_destroy_plan": true,
+            "assessments_enabled": false,
+            "auto_apply": false,
+            "auto_apply_run_trigger": false,
+            "description": "",
+            "execution_mode": "remote",
+            "file_triggers_enabled": true,
+            "force_delete": false,
+            "global_remote_state": false,
+            "html_url": "https://app.terraform.io/app/PulsePixel/workspaces/pixel_predict_default",
+            "id": "ws-wZjbkT1jfHJhDLHY",
+            "ignore_additional_tag_names": null,
+            "name": "pixel_predict_default",
+            "operations": true,
+            "organization": "PulsePixel",
+            "project_id": "prj-xoJ9naqKrG19yiAQ",
+            "queue_all_runs": false,
+            "remote_state_consumer_ids": [],
+            "resource_count": 0,
+            "source_name": "",
+            "source_url": "",
+            "speculative_enabled": true,
+            "ssh_key_id": "",
+            "structured_run_output_enabled": true,
+            "tag_names": [
+              "pixel_predict"
+            ],
+            "terraform_version": "1.9.2",
+            "trigger_patterns": null,
+            "trigger_prefixes": null,
+            "vcs_repo": [],
+            "working_directory": ""
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjEifQ==",
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"PixelPredict\"]",
+      "mode": "managed",
+      "type": "tfmigrate_state_migration",
+      "name": "state-migration",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "index_key": "default",
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/PixelPredict",
+            "local_workspace": "default",
+            "org": "PulsePixel",
+            "tfc_workspace": "pixel_predict_default"
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"PixelPredict\"]",
+      "mode": "managed",
+      "type": "tfmigrate_terraform_init",
+      "name": "terraform_init",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/PixelPredict",
+            "summary": "Terraform Init Completed."
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    },
+    {
+      "module": "module.workspace_and_variables[\"PixelPredict\"]",
+      "mode": "managed",
+      "type": "tfmigrate_update_backend",
+      "name": "update-backend",
+      "provider": "provider[\"registry.terraform.io/hashicorp/tfmigrate\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "backend_file_name": "main.tf",
+            "directory_path": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/PixelPredict",
+            "id": "/Users/sujaysamanta/Workspace/Vs-Code-CodeBase/tf-migrate-bug-bash/PixelPredict",
+            "org": "PulsePixel",
+            "project": "pixel_predict",
+            "tags": [
+              "pixel_predict"
+            ],
+            "workspace_map": {
+              "default": "pixel_predict_default"
+            }
+          },
+          "sensitive_attributes": [],
+          "dependencies": [
+            "module.workspace_and_variables.data.tfe_project.project",
+            "module.workspace_and_variables.tfe_workspace.workspaces",
+            "module.workspace_and_variables.tfmigrate_state_migration.state-migration",
+            "module.workspace_and_variables.tfmigrate_terraform_init.terraform_init",
+            "tfe_project.list_of_new_projects"
+          ]
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}

--- a/main.tf
+++ b/main.tf
@@ -8,10 +8,12 @@ terraform {
     }
   }
 
-  backend "s3" {
-    bucket = "pixelpredict"
-    key    = "terraform/state/main.tfstate"
-    region = "us-west-1"
+  cloud {
+    organization = "PulsePixel"
+    workspaces {
+      project = "pixel_predict"
+      name    = "pixel_predict_default"
+    }
   }
 }
 


### PR DESCRIPTION
This PR is created by TFMigrate CLI to migrate the Workspaces from the repository PulsePixel/PixelPredict to the HCP Workspace.